### PR TITLE
TMT: Build and Verify in CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,8 +9,8 @@ jobs:
     skip_build: true
     notifications:
       failure_comment:
-        message: "container build test failed. @containers/packit-build please check."
+        message: "Tests failed. @containers/packit-build please check."
     targets:
-      - fedora-rawhide
-    identifier: build_container_test
-    tmt_plan: "/plans/build_container_test"
+      - fedora-latest-stable
+    identifier: build_and_verify
+    tmt_plan: "/plans/build_and_verify"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -exo pipefail
+
 source ./util.sh
 
 

--- a/plans/build_container_test.sh
+++ b/plans/build_container_test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -exo pipefail
-
-podman build -t quay.io/podman/machine-os:latest -f podman-image-daily/Containerfile ${PWD}/podman-image-daily

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,10 +1,29 @@
 prepare:
     - how: install
       package:
+        - golang
+        - osbuild
+        - osbuild-ostree
+        - osbuild-tools
         - podman
+        - podman-machine
+        - podman-remote
+        - gvisor-tap-vsock
+        - zstd
 
-/build_container_test:
-    summary: Build Container
+/build_and_verify:
+    summary: Build and Verify
+    provision:
+        how: artemis
+        hardware:
+            virtualization:
+                is-virtualized: false
     execute:
         how: tmt
-        script: bash ./plans/build_container_test.sh
+        script: |
+            setenforce 0
+            OCI_VERSION="5.3"  DISK_IMAGE_NAME="podman-machine" OCI_NAME="machine-osstage-5.3" sh build.sh
+            chown -R fedora:fedora ./*
+            cd verify
+            runuser fedora -c 'go install github.com/onsi/ginkgo/v2/ginkgo'
+            runuser fedora -c 'TMPDIR=/var/tmp MACHINE_IMAGE_PATH="../outdir/podman-machine.x86_64.qemu.qcow2.zst" PATH=$PATH:~/go/bin sh run_test.sh'

--- a/verify/run_test.sh
+++ b/verify/run_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -exo pipefail
 
 MACHINE_PATH=${MACHINE_IMAGE_PATH}
 


### PR DESCRIPTION
This commit will enable `build.sh` and `verify/run_test.sh` runs in upstream CI.
