### PR TITLE
Enable tests for Windows HyperV

### DIFF
--- a/verify/README.md
+++ b/verify/README.md
@@ -29,17 +29,27 @@ You can also set the path to the disk image with an environment variable such as
 
 `$ PODMAN_MACHINE_IMAGE=/path/to/disk/image sh run_test.sh`
 
+#### MacOS
 On MacOS, **you will need to set the TMPDIR environment variable** to avoid a
 limitation in MacOS where socket lengths cannot exceed 120-some characters.
 For example:
 
 `$ TMPDIR=/Users/brentbaude/ sh run_test.sh /path/to/disk/image`
 
-### Operating Systems with multiple machine providers
-
-Both Windows and MacOS support multiple machine providers. Windows supports
-`WSL` and `HyperV`, where WSL is the default provider.  On MacOS, `applehv` and `libkrun`
-are both supported and `applehv` is the default. You can also the provider used by
-the tests with an environment variable, such as the following on MacOS:
+For MacOs, we support both `applehv` and `libkrun` machine providers.  The `applehv` provider is the default.
+To switch providers in MacOS, you can either set it in a `containers.conf` in `~/.config/containers/`. You can
+also specify the provider through an environment variable like so:
 
 `$ TMPDIR=/Users/brentbaude CONTAINERS_MACHINE_PROVIDER=libkrun sh run_test.sh /path/to/disk/image`
+
+#### Windows HyperV
+
+Remember that HyperV in Podman machine requires Administrator authority so be certain to open an
+administrator powershell.  Then make sure you set the HyperV provider. The simplest approach is using an
+environment variable.
+
+`> $Env:CONTAINERS_MACHINE_PROVIDER="hyperv"`
+
+To run the suite, use the Powershell script.
+
+`> .\win_run_test.ps1 c:\Path\To\Disk\Image`

--- a/verify/config_windows.go
+++ b/verify/config_windows.go
@@ -1,0 +1,5 @@
+package verify
+
+func getPodmanBinaryName() string {
+	return "podman"
+}

--- a/verify/run_test.sh
+++ b/verify/run_test.sh
@@ -15,4 +15,4 @@ if [[ ! ${MACHINE_PATH} ]]; then
 echo "using images from ${MACHINE_PATH}"
 export MACHINE_IMAGE_PATH=$MACHINE_PATH
 
-ginkgo
+ginkgo -v

--- a/verify/win_run_test.ps1
+++ b/verify/win_run_test.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env powershell
+
+# Small helper to avoid needing to write 'Check-Exit' after every
+# non-powershell instruction.  It simply prints then executes the _QUOTED_
+# argument followed by Check-Exit.
+# N/B: Escape any nested quotes with back-tick ("`") characters.
+# WARNING: DO NOT use this with powershell builtins! It will not do what you expect!
+function Run-Command {
+    param (
+        [string] $command
+    )
+
+    Write-Host $command
+
+    # The command output is saved into the variable $unformattedLog to be
+    # processed by `logformatter` later. The alternative is to redirect the
+    # command output to logformatter using a pipeline (`|`). But this approach
+    # doesn't work as the command exit code would be overridden by logformatter.
+    # It isn't possible to get a behavior of bash `pipefail` on Windows.
+    Invoke-Expression $command -OutVariable unformattedLog | Write-Output
+
+    $exitCode = $LASTEXITCODE
+
+    if ($Env:CIRRUS_CI -eq "true") {
+        Invoke-Logformatter $unformattedLog
+    }
+
+    Check-Exit 2 "'$command'" "$exitCode"
+}
+
+# Non-powershell commands do not halt execution on error!  This helper
+# should be called after every critical operation to check and halt on a
+# non-zero exit code.  Be careful not to use this for powershell commandlets
+# (builtins)!  They set '$?' to "True" (failed) or "False" success so calling
+# this would mask failures.  Rely on $ErrorActionPreference = 'Stop' instead.
+function Check-Exit {
+    param (
+        [int] $stackPos = 1,
+        [string] $command = 'command',
+        [string] $exitCode = $LASTEXITCODE # WARNING: might not be a number!
+    )
+
+    if ( ($exitCode -ne $null) -and ($exitCode -ne 0) ) {
+        # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.callstackframe
+        $caller = (Get-PSCallStack)[$stackPos]
+        throw "Exit code = '$exitCode' running $command at $($caller.ScriptName):$($caller.ScriptLineNumber)"
+    }
+}
+
+
+if ($args.Count -lt 1) {
+    Write-Output "Must supply fully-qualified path to machine image"
+    exit 1
+}
+
+# Set required environment variable for ginkgo and the test suite
+$env:MACHINE_IMAGE_PATH=$args[0]
+
+# Run the tests
+Run-Command "ginkgo -v"


### PR DESCRIPTION
You can now test Windows HyperV machine images using the verify test suite.  This PR includes some windows specific things.  It also includes a powershell script that mimics the run_test.sh used for Linux and MacOS.  And finally, updated the documentation to reflect how Windows HyperV can be tested.