### PR TITLE
Add gvisor-tap-vsock-gvforwarder to machine image

### DIFF
--- a/podman-image-daily/Containerfile
+++ b/podman-image-daily/Containerfile
@@ -44,7 +44,8 @@ RUN rpm-ostree override replace --experimental --freeze \
 
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc
-RUN rpm-ostree install subscription-manager qemu-user-static && rm -fr /var/cache
+# Install gvisor-tap-vsock-gvforwarder for hyperv
+RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static && rm -fr /var/cache
 RUN systemctl enable rhsmcertd.service
 # Patching qemu backed binfmt configurations to use the actual executable's permissions and not the interpreter's
 RUN for x in /usr/lib/binfmt.d/*.conf; do sed 's/\(:[^C:]*\)$/\1C/' "$x" | tee /etc/binfmt.d/"$(basename "$x")"; done


### PR DESCRIPTION
Recent changes in RPM specs dropped the hard requires on this package and we need to make sure it is installed into the machine image.