### PR TITLE
TMT: allow artifact fetching

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,7 @@ jobs:
       failure_comment:
         message: "Tests failed. @containers/packit-build please check."
     targets:
-      - fedora-latest-stable
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
     identifier: build_and_verify
     tmt_plan: "/plans/build_and_verify"

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ source ./util.sh
 
 echo "Preparing to build ${FULL_IMAGE_NAME}"
 
-mkdir $OUTDIR
+mkdir -p $OUTDIR
 git clone https://github.com/dustymabe/build-podman-machine-os-disks
 
 echo " Building image locally"
@@ -19,7 +19,8 @@ echo "Saving image from image store to filesystem"
 podman save --format oci-archive -o "${OUTDIR}/${DISK_IMAGE_NAME}" "${FULL_IMAGE_NAME_ARCH}"
 
 echo "Transforming OCI image into disk image"
-cd $OUTDIR && sudo sh  ../build-podman-machine-os-disks/build-podman-machine-os-disks.sh "${PWD}/${DISK_IMAGE_NAME}"
+SRCDIR="${TMT_TREE:-..}"
+cd $OUTDIR && sudo sh $SRCDIR/build-podman-machine-os-disks/build-podman-machine-os-disks.sh "${PWD}/${DISK_IMAGE_NAME}"
 
 echo "Compressing disk images with zstd"
 # note: we are still "in" the outdir at this point

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -22,8 +22,12 @@ prepare:
         how: tmt
         script: |
             setenforce 0
-            OCI_VERSION="5.3"  DISK_IMAGE_NAME="podman-machine" OCI_NAME="machine-osstage-5.3" sh build.sh
+            export BASENAME="machine-os"
+            export ARCH=$(uname -m)
+            export PODMAN_VERSION="5.3"
+            OCI_VERSION="$PODMAN_VERSION"  DISK_IMAGE_NAME="$BASENAME-$PODMAN_VERSION" OCI_NAME="machine-osstage-$PODMAN_VERSION" sh build.sh
+            tar cvf $TMT_TEST_DATA/$BASENAME-$PODMAN_VERSION-$ARCH.tar $TMT_TEST_DATA/$BASENAME-$PODMAN_VERSION
             chown -R fedora:fedora ./*
             cd verify
             runuser fedora -c 'go install github.com/onsi/ginkgo/v2/ginkgo'
-            runuser fedora -c 'TMPDIR=/var/tmp MACHINE_IMAGE_PATH="../outdir/podman-machine.x86_64.qemu.qcow2.zst" PATH=$PATH:~/go/bin sh run_test.sh'
+            runuser fedora -c 'TMPDIR=/var/tmp MACHINE_IMAGE_PATH="$TMT_TEST_DATA/$BASENAME-$PODMAN_VERSION.$ARCH.qemu.qcow2.zst" PATH=$PATH:~/go/bin sh run_test.sh'

--- a/util.sh
+++ b/util.sh
@@ -44,7 +44,7 @@ DISK_FLAVORS_W_SUFFIX=("applehv.raw" "hyperv.vhdx" "qemu.qcow2")
 
 REPO="${REPO:-quay.io/podman}"
 DISK_IMAGE_NAME="${DISK_IMAGE_NAME:-stage-machine-os}"
-OUTDIR="outdir"
+OUTDIR="${TMT_TEST_DATA:-outdir}"
 BUILD_SCRIPT="./build-podman-machine-os-disks/build-podman-machine-os-disks.sh"
 OCI_NAME="${OCI_NAME:-podman-machine-daily}"
 OCI_VERSION="${OCI_VERSION:-unknown}"


### PR DESCRIPTION
Testing farm environments set the `TMT_TEST_DATA` variable.
    
From the TMT docs:
TMT_TEST_DATA: Path to the directory where test can store logs and other artifacts generated during its execution.    These will be pulled back from the guest and available for inspection after the test execution is finished.
    
Ref: https://tmt.readthedocs.io/en/stable/overview.html#variables
