### PR TITLE
Add github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Thanks for sending a pull request!
+
+Please make your commit messages insightful so we start a decent history. If you
+add something to the main Containerfile, please ensure you add a test in `verify/`
+so we can protect against regressions.
+-->
+
+<!--
+If no, just write `None` in the release-note block below. If yes, a release note
+is required: Enter your extended release note in the block below. If the PR
+requires additional action from users switching to the new release, include the
+string "action required".
+
+For more information on release notes, please follow the Kubernetes model:
+https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
The openshift bot requires a release note now so I added a PR template to help users.


```release-note
Added PR template to repository to help with PR consistency.
```
