### PR TITLE
Clean up after each test

### DIFF
--- a/verify/image_verify_test.go
+++ b/verify/image_verify_test.go
@@ -54,7 +54,11 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterEach(func() {
-	fmt.Println("Goodbye world")
+	clean := []string{"machine", "reset", "-f"}
+	_, err := mb.setCmd(clean).run()
+	if err != nil {
+		fmt.Println("Error cleaning up after test: ", err)
+	}
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {


### PR DESCRIPTION
I think tests were failing on windows because the suite tried to remove the testdirs and the machines had not been cleaned up.  This is fine with Linux but on HyperV, it is not allowed by its filesystem handling. Adding a machine reset -f to test cleanup.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
