### PR TITLE
verify: cleanup machines after each test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,8 +89,7 @@ test_task:
     alias: success
     depends_on:
         - image_build
-        # Windows fails with file in use so make it ""optional" by not failing success task on it
-        # - verify_windows
+        - verify_windows
     container:
         image: "${FEDORA_CONTAINER_FQIN}"
         cpu: 1

--- a/verify/image_verify_test.go
+++ b/verify/image_verify_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 func TestMain(m *testing.M) {
@@ -130,7 +131,15 @@ var (
 var _ = BeforeEach(func() {
 	testDir, mb = setup()
 	DeferCleanup(func() {
+		// stop and remove all machines first before deleting the processes
+		clean := []string{"machine", "reset", "-f"}
+		session, err := mb.setCmd(clean).run()
+
 		teardown(originalHomeDir, testDir)
+
+		// check errors only after we called teardown() otherwise it is not called on failures
+		Expect(err).ToNot(HaveOccurred(), "cleaning up after test")
+		Expect(session).To(Exit(0))
 	})
 })
 


### PR DESCRIPTION
We have to cleanup the machines to not leak them and keep them running, thanks to Brent for catching this.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
