### PR TITLE
github: Fix wrong name in action

### DIFF
--- a/.github/workflows/pr_image_links.yml
+++ b/.github/workflows/pr_image_links.yml
@@ -68,7 +68,7 @@ jobs:
               run: ./contrib/cirrus/print-artifacts-urls.sh "${{ steps.retro.outputs.bid }}"
 
             - if: steps.retro.outputs.is_pr == 'true'
-              name: Count the number of manifest.json files downloaded
+              name: Send GitHub PR comment
               uses: thollander/actions-comment-pull-request@v3
               with:
                   pr-number: ${{ steps.retro.outputs.prn }}


### PR DESCRIPTION
Some copy paste leftover from me. The name makes no sense we are sending the comment there.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
