### PR TITLE
New VM images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ env:
     # Vars used for the macos and windows testing
     MACHINE_IMAGE_BASE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/"
     # podman version used by windows/macos verify suite
-    PODMAN_INSTALL_VERSION: 5.3.0
+    PODMAN_INSTALL_VERSION: 5.3.1
 
 gcp_credentials: ENCRYPTED[b06ef3490b73469d9da1402568d6f3e46a852955a4ab0807689d50352ecf2852cb5903e8d3b7603eaab9d1c7c7d851a5]
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ env:
     CIRRUS_WORKING_DIR: /var/tmp/podman-machine-os
 
     # Vars used for the macos and windows testing
-    MACHINE_IMAGE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/Image Build ${ARCH}/image/${MACHINE_IMAGE}"
+    MACHINE_IMAGE_BASE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/"
     # podman version used by windows/macos verify suite
     PODMAN_INSTALL_VERSION: 5.3.0
 
@@ -121,9 +121,7 @@ verify_macos_task:
 
     prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
     setup_script: |
-        # curl does not accept URL with spaces, we need to URL encode (string replace with %20)
-        MACHINE_IMAGE_URL="${MACHINE_IMAGE_URL// /%20}"
-        curl --retry 5 --retry-delay 8 --fail --location -O --url "${MACHINE_IMAGE_URL}"
+        curl --retry 5 --retry-delay 8 --fail --location -O --url "${MACHINE_IMAGE_BASE_URL}${MACHINE_IMAGE}"
         git clone --depth 1 --branch v${PODMAN_INSTALL_VERSION} https://github.com/containers/podman.git
         make -C podman podman-remote
         ./podman/bin/darwin/podman --version
@@ -170,7 +168,7 @@ image_push_task:
         for end in applehv.raw.zst hyperv.vhdx.zst qemu.qcow2.zst tar; do
             for arch in x86_64 aarch64; do
                 name="podman-machine.$arch.$end"
-                curl --retry 5 --retry-delay 8 --fail --location -O --output-dir $OUTDIR --url https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/$name
+                curl --retry 5 --retry-delay 8 --fail --location -O --output-dir $OUTDIR --url "${MACHINE_IMAGE_BASE_URL}$name"
             done
         done
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,15 +43,18 @@ image_build_task:
         image: "${VM_IMAGE}"
         type: "${EC2_INST_TYPE}"
         region: us-east-1
+        architecture: "${GO_ARCH}"
     env:
         HOME: /root
     matrix:
         - env:
             ARCH: "x86_64"
+            GO_ARCH: "amd64"
             VM_IMAGE: "${FEDORA_AMI}"
             EC2_INST_TYPE: "m5zn.metal"  # Bare-metal instance is required
         - env:
             ARCH: "aarch64"
+            GO_ARCH: "arm64"
             VM_IMAGE: "${FEDORA_AARCH64_AMI}"
             EC2_INST_TYPE: "c6g.metal"  # Bare-metal instance is required
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20241016t144444z-f40f39d13"
+    IMAGE_SUFFIX: "c20241205t124648z-f41f40d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -2,10 +2,6 @@
 
 set -xeo pipefail
 
-# install extra dependencies.
-# TODO: Do we need to move them into the image build process?
-dnf install -y osbuild osbuild-tools osbuild-ostree jq xfsprogs e2fsprogs podman podman-machine podman-remote gvisor-tap-vsock
-
 # Build process must run with selinux disabled?!
 setenforce 0
 

--- a/contrib/cirrus/windows_setup.ps1
+++ b/contrib/cirrus/windows_setup.ps1
@@ -21,8 +21,8 @@ function download($uri, $file) {
     }
 }
 
-# Download the machine image from the prevoius build job
-download "${ENV:MACHINE_IMAGE_URL}" "${ENV:MACHINE_IMAGE}"
+# Download the machine image from the previous build job
+download "${ENV:MACHINE_IMAGE_BASE_URL}${ENV:MACHINE_IMAGE}" "${ENV:MACHINE_IMAGE}"
 
 # Download and install podman
 $uri = "https://github.com/containers/podman/releases/download/v${ENV:PODMAN_INSTALL_VERSION}/podman-${ENV:PODMAN_INSTALL_VERSION}-setup.exe"


### PR DESCRIPTION
from https://github.com/containers/automation_images/pull/396

The images should include the required rpms so we this should speed up the tests as we do not have to pull them and should not unexpectly break the build.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
