### PR TITLE
cirrus: lower timeout again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,8 +39,6 @@ timeout_in: 30m
 image_build_task:
     name: "Image Build ${ARCH}"
     alias: "image_build"
-    # Building takes a long time so give it a bit more timeout.
-    timeout_in: 45m
     ec2_instance:
         image: "${VM_IMAGE}"
         type: "${EC2_INST_TYPE}"


### PR DESCRIPTION
It is no longer needed with the build script speed up from commit 8ead68e.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
