### PR TITLE
Fix ssh auth errors when starting the machine

### DIFF
--- a/podman-image/99-podman-sshd.conf
+++ b/podman-image/99-podman-sshd.conf
@@ -1,0 +1,5 @@
+# There seems to be big problem on macos with connecting to ssh to early and
+# it seems to count that as auth failure locking us out. Podman machine only
+# runs locally and there ar eno remote users that can connect so just disable
+# it.
+PerSourcePenalties authfail:0

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -11,12 +11,14 @@ ARG PODMAN_RPM_URL="https://kojipkgs.fedoraproject.org/packages/podman/${PODMAN_
 RUN mkdir -p /etc/containers/registries.conf.d && \
     mkdir -p /etc/systemd/system.conf.d && \
     mkdir -p /etc/environment.d && \
-    mkdir -p /etc/containers/registries.conf.d
+    mkdir -p /etc/containers/registries.conf.d && \
+    mkdir -p /etc/ssh/sshd_config.d
 
 COPY  50-podman-makestep.conf /etc/chrony.d/50-podman-makestep.conf
 COPY  docker-host.sh /etc/profile.d/docker-host.sh
 COPY  999-podman-machine.conf /etc/containers/registries.conf.d/999-podman-machine.conf
 COPY  10-inotify-instances.conf /etc/sysctl.d/10-inotify-instances.conf
+COPY  99-podman-sshd.conf /etc/ssh/sshd_config.d/99-podman-sshd.conf
 
 ## Enables automatic login on the console;
 ## there's no security concerns here, and this makes debugging easier.

--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -107,4 +107,22 @@ var _ = Describe("run basic podman commands", func() {
 				To(Equal("ostree-remote-image:fedora:docker://quay.io/podman/machine-os:" + version))
 		}
 	})
+
+	It("machine stop/start cycle", func() {
+		// We have seen an issue while stopping and starting machines again
+		// and then causing ssh failures on the second start. So test it.
+		machineName, session, err := mb.initNowWithName()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		stopMachineCmd := []string{"machine", "stop", machineName}
+		stopMachineSession, err := mb.setCmd(stopMachineCmd).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopMachineSession).To(Exit(0))
+
+		startMachineCmd := []string{"machine", "start", machineName}
+		startMachineSession, err := mb.setCmd(startMachineCmd).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(startMachineSession).To(Exit(0))
+	})
 })


### PR DESCRIPTION
On macos we often seem to hit this error when starting the machine: machine did not transition into running state: ssh error: ssh: handshake failed: EOF

As it turns out the problem is caused by the new PerSourcePenalties sshd feature, after 5 failed log ins it locks us out. As podman machine only runs locally we do not need that extra security and can just disable it. It is unclear why our early login attempts are counted towards failed attempts as we always use the same ssh key but this here fixes the problem. And for now we like to get this in to get the podman CI working again.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a problem with ssh connection on macos.
```
