### PR TITLE
add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,50 @@
+/*
+
+Validate this file before committing with (from repository root):
+
+    podman run -it \
+        -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
+        ghcr.io/renovatebot/renovate:latest \
+        renovate-config-validator
+
+and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
+*/
+
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  /*************************************************
+   ****** Global/general configuration options *****
+   *************************************************/
+
+  // Reuse predefined sets of configuration options to DRY
+  "extends": [
+    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
+    "github>containers/automation//renovate/defaults.json5"
+  ],
+
+  /*************************************************
+   *** Repository-specific configuration options ***
+   *************************************************/
+
+  "ignorePaths": [
+    "**/vendor/**",
+    "**/docs/**",
+  ],
+
+  "addLabels": ["release-note-none"],
+
+  "customManagers": [
+    // Track updates on
+    {
+      "customType": "regex",
+      "fileMatch": "^build.sh$",
+      // Expected version format: gitreporef="xxx"
+      "matchStrings": ["gitreporef=\"(?<currentDigest>.*?)\"\\n"],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "custom-coreos-disk-images",
+      "packageNameTemplate": "https://github.com/coreos/custom-coreos-disk-images",
+      "datasourceTemplate": "git-refs"
+    },
+  ]
+}


### PR DESCRIPTION
Add renovate to update the go deps, the cirrus image version and with a custom manager the core script git sha so we do not lack behind there. Taken from this example:
https://docs.renovatebot.com/modules/datasource/git-refs/

Fixes #53

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a renovate config to auto update deps
```
