### PR TITLE
update coreos script download comment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,9 +6,9 @@ source ./util.sh
 
 echo "Preparing to build ${FULL_IMAGE_NAME}"
 
-# Freeze on specific version for now to increase stability.
-#gitreporef="main"
-# TODO: setup/configure renovate to update the sha here.
+# Freeze on specific commit to increase stability.
+# Renovate is configured to update to a new commit so do not update the format
+# without updating the renovate config, see .github/renovate.json5.
 gitreporef="06c3faf27826e17d6ea051ad023ba38879593e1b"
 gitrepotld="https://raw.githubusercontent.com/coreos/custom-coreos-disk-images/${gitreporef}/"
 curl -LO --fail "${gitrepotld}/custom-coreos-disk-images.sh"


### PR DESCRIPTION
It is updated with renovate now, and per #57 the regex worked but picked up the comment which we no longer need.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
