### PR TITLE
Release RPM: Fetch from Podman upstream PR

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,22 +15,18 @@ curl -LO --fail "${gitrepotld}/custom-coreos-disk-images.sh"
 
 echo " Building image locally"
 
-# Validate podman RPM type var, see the Containerfile for the pull logic.
-case "${PODMAN_RPM_TYPE}" in
-  "dev") echo "Will install podman from the podman-next copr, the podman version is ignored" ;;
-  "release") ;;
-  *) echo 'PODMAN_RPM_TYPE must be set to "dev" or "release"' 1>&2; exit 1
+# Validate PODMAN_PR_NUM var, see the Containerfile for the pull logic.
+case "${PODMAN_PR_NUM}" in
+  '') echo "Will install podman from the podman-next copr, the podman version is ignored" ;;
+  [0-9]*) ;;
+  *) echo 'PODMAN_PR_NUM must be empty or set to a valid PR number' 1>&2; exit 1;;
 esac
 
-# See podman-rpm-info-vars.sh for all build-arg values. If PODMAN_RPM_TYPE is
-# "dev", the rpm version, release and fedora release values are of no concern
+# See podman-rpm-info-vars.sh for all build-arg values. If PODMAN_PR_NUM is
+# empty, the rpm version, release and fedora release values are of no concern
 # to the build process.
 podman build -t "${FULL_IMAGE_NAME_ARCH}" -f podman-image/Containerfile ${PWD}/podman-image \
-    --build-arg PODMAN_RPM_TYPE=${PODMAN_RPM_TYPE} \
-    --build-arg PODMAN_VERSION=${PODMAN_VERSION} \
-    --build-arg PODMAN_RPM_RELEASE=${PODMAN_RPM_RELEASE} \
-    --build-arg FEDORA_RELEASE=$(rpm --eval '%{?fedora}') \
-    --build-arg ARCH=$(uname -m)
+    --build-arg PODMAN_PR_NUM=${PODMAN_PR_NUM}
 
 echo "Saving image from image store to filesystem"
 

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -1,11 +1,6 @@
 FROM quay.io/fedora/fedora-coreos:stable
 
-ARG PODMAN_RPM_TYPE=${PODMAN_RPM_TYPE}
-ARG PODMAN_VERSION=${PODMAN_VERSION}
-ARG PODMAN_RPM_RELEASE=${PODMAN_RPM_RELEASE}
-ARG FEDORA_RELEASE=${FEDORA_RELEASE}
-ARG ARCH=${ARCH}
-ARG PODMAN_RPM_URL="https://kojipkgs.fedoraproject.org/packages/podman/${PODMAN_VERSION}/${PODMAN_RPM_RELEASE}.fc${FEDORA_RELEASE}/${ARCH}/podman-${PODMAN_VERSION}-${PODMAN_RPM_RELEASE}.fc${FEDORA_RELEASE}.${ARCH}.rpm"
+ARG PODMAN_PR_NUM=${PODMAN_PR_NUM}
 
 # Make required directories
 RUN mkdir -p /etc/containers/registries.conf.d && \
@@ -31,27 +26,26 @@ COPY  10-autologin.conf /etc/systemd/system/getty@.service.d/10-autologin.conf
 ## by default
 COPY delegate.conf /etc/systemd/system/user@.service.d/delegate.conf
 
-# Setup the podman-next copr repo
-# The source file for the dnf repo may say `rawhide` but it's release
-# agnostic and `rawhide` in the name is unlikely to change compared
-# with URLs containing fedora release numbers.
-ADD https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repos /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo
-ADD https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg
-
-# 1. For dev builds, replace aardvark-dns, conmon, crun, netavark, podman, containers-common
-# 2. For release builds, fetch the build from koji
+# 1. For main branch builds, replace aardvark-dns, conmon, crun, netavark, podman, containers-common
+# 2. For release branch builds, fetch the build from the copr job on the podman
+# release PR.
 # 3. Remove moby-engine, containerd, runc, zincati for both dev and release builds
 # Note: Currently does not result in a size reduction for the container image
-
-RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
+# 4. Even though the URLs mention `rawhide`, the repo and gpg files are Fedora
+# release agnostic and such `rawhide` URLs are unlikely to change compared to URLs
+# containing Fedora release numbers.
+RUN if [[ ${PODMAN_PR_NUM} == "" ]]; then \
+        curl -o /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repo && \
+        curl -o /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg && \
         rpm-ostree override replace --experimental --freeze \
         --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
         aardvark-dns crun netavark podman containers-common containers-common-extra crun-wasm; \
     else \
-        rm /etc/yum.repos.d/rhcontainerbot*.repo /etc/pki/rpm-gpg/rhcontainerbot*.gpg && \
-        if [[ $(rpm -q podman) != "podman-${PODMAN_VERSION}-${PODMAN_RPM_RELEASE}.fc${FEDORA_RELEASE}.${ARCH}" ]]; then \
-            rpm-ostree override replace ${PODMAN_RPM_URL}; \
-        fi \
+        curl -o /etc/yum.repos.d/podman-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/containers-podman-${PODMAN_PR_NUM}/repo/fedora-rawhide/packit-containers-podman-${PODMAN_PR_NUM}-fedora-rawhide.repo && \
+        curl -o /etc/pki/rpm-gpg/podman-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/containers-podman-${PODMAN_PR_NUM}/pubkey.gpg && \
+        rpm-ostree override replace --experimental --freeze \
+        --from repo="copr:copr.fedorainfracloud.org:packit:containers-podman-${PODMAN_PR_NUM}" \
+        podman; \
     fi && \
     rpm-ostree override remove moby-engine containerd runc && \
     rm -fr /var/cache && \

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-# Set to "dev" to pull from the podman-next copr, set to "release"
-# to pull the ext rom from the fedora build system based of the versions below.
-export PODMAN_RPM_TYPE="dev"
-
-# PODMAN_VERSION is used for fetching the right rpm when PODMAN_RPM_TYPE is set to release.
-# However it is always used to derive the machine-os image tag (x.y) so this must be valid
+# 1. PODMAN_VERSION is always used to derive the machine-os image tag (x.y) so this must be valid
 # at any given time.
+# 2. Both PODMAN_VERSION and PODMAN_PR_NUM will have to be updated manually on release
+# PRs.
+# 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/podman-next` copr.
 export PODMAN_VERSION="5.5.0-dev"
-export PODMAN_RPM_RELEASE="1"
+export PODMAN_PR_NUM=""


### PR DESCRIPTION
This commit will allow fetching the podman rpm from the upstream Podman release PR's (or any PR for that matter) Packit copr job.

At this point, the upstream PR is assumed to have passed system tests using the rpms generated in its copr job.

The copr created by Packit on the Podman release PR will be preserved indefinitely.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fetch rpm from upstream podman PR's copr build job
```
