### PR TITLE
Add ansible to podman-machine-os

### DIFF
--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -58,7 +58,8 @@ RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc
 # Install gvisor-tap-vsock-gvforwarder for hyperv
-RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static && rm -fr /var/cache
+# Install ansible for post-install configuration
+RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static ansible-core && rm -fr /var/cache
 
 RUN systemctl enable rhsmcertd.service
 # Patching qemu backed binfmt configurations to use the actual executable's permissions and not the interpreter's


### PR DESCRIPTION
add ansible to the machine image so users can execute a playbook once the machine is booted.  Users have been asking for a way to automaticaly configure a machine with various options, files (like certificates), and configuration tweaks.  Ansible is an excellent tool to do this in the machine.
    
See also containers/podman#25043
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add ansible package to base image
```
