### PR TITLE
auto load ip_tables modules on boot

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,10 +99,10 @@ verify_macos_task:
     depends_on:
         - image_build
     persistent_worker: &mac_pw
-    labels:
-        os: darwin
-        arch: arm64
-        purpose: prod
+        labels:
+            os: darwin
+            arch: arm64
+            purpose: prod
     env: &mac_env
         ARCH: "aarch64"
         CIRRUS_SHELL: "/bin/bash"  # sh is the default

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -19,6 +19,7 @@ COPY  docker-host.sh /etc/profile.d/docker-host.sh
 COPY  999-podman-machine.conf /etc/containers/registries.conf.d/999-podman-machine.conf
 COPY  10-inotify-instances.conf /etc/sysctl.d/10-inotify-instances.conf
 COPY  99-podman-sshd.conf /etc/ssh/sshd_config.d/99-podman-sshd.conf
+COPY  podman-iptables.conf /etc/modules-load.d/podman-iptables.conf
 
 ## Enables automatic login on the console;
 ## there's no security concerns here, and this makes debugging easier.

--- a/podman-image/podman-iptables.conf
+++ b/podman-image/podman-iptables.conf
@@ -1,0 +1,11 @@
+# On fedora 41 we switched netavark to nftables and no longer load ip tables
+# modules: https://github.com/containers/podman/pull/24109
+# While we no longer need it applications running inside a container might
+# still need it, i.e. nested docker or older podman.
+# Normally it would be up to the sys admin to configure this but given
+# podman machine os is more of "managed" OS we should just keep it to
+# avoid breaking users, https://github.com/containers/podman/issues/25153.
+# TODO (6.0): consider removing this in a major release where we can justify
+# removing legacy modules.
+ip_tables
+ip6_tables

--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -87,10 +87,17 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
+		// https://github.com/containers/podman-machine-os/issues/18
 		sshSession, err := mb.setCmd([]string{"machine", "ssh", machineName, "sudo", "systemctl", "is-active", "systemd-resolved.service"}).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession).To(Exit(3))
 		Expect(sshSession.outputToString()).To(Equal("inactive"))
+
+		// https://github.com/containers/podman/issues/25153
+		sshSession, err = mb.setCmd([]string{"machine", "ssh", machineName, "sudo", "lsmod"}).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sshSession).To(Exit(0))
+		Expect(sshSession.outputToString()).To(And(ContainSubstring("ip_tables"), ContainSubstring("ip6_tables")))
 
 		// set by podman-rpm-info-vars.sh
 		if version := os.Getenv("PODMAN_VERSION"); version != "" {


### PR DESCRIPTION
On fedora 41 we switched netavark to nftables and no longer load ip tables modules: https://github.com/containers/podman/pull/24109 While we no longer need it applications running inside a container might still need it, i.e. nested docker or older podman. Normally it would be up to the sys admin to configure this but given podman machine os is more of "managed" OS we should just keep it to avoid breaking users.

Fixes https://github.com/containers/podman/issues/25153

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The ip_tables and ip6_tables kernel modules will be loaded again by default. 
```
