### PR TITLE
fix broken exit code checks in rpm-ostree install

### DIFF
--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -48,13 +48,14 @@ RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
         --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
         aardvark-dns crun netavark podman containers-common containers-common-extra crun-wasm; \
     else \
-        rm /etc/yum.repos.d/rhcontainerbot*.repo /etc/pki/rpm-gpg/rhcontainerbot*.gpg; \
+        rm /etc/yum.repos.d/rhcontainerbot*.repo /etc/pki/rpm-gpg/rhcontainerbot*.gpg && \
         if [[ $(rpm -q podman) != "podman-${PODMAN_VERSION}-${PODMAN_RPM_RELEASE}.fc${FEDORA_RELEASE}.${ARCH}" ]]; then \
             rpm-ostree override replace ${PODMAN_RPM_URL}; \
-        fi; \
-    fi; \
-    rpm-ostree override remove moby-engine containerd runc; \
-    rm -fr /var/cache && ostree container commit
+        fi \
+    fi && \
+    rpm-ostree override remove moby-engine containerd runc && \
+    rm -fr /var/cache && \
+    ostree container commit
 
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -61,7 +61,9 @@ RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
 # Install qemu-user-static for bootc
 # Install gvisor-tap-vsock-gvforwarder for hyperv
 # Install ansible for post-install configuration
-RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static ansible-core && rm -fr /var/cache
+RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static ansible-core && \
+    rm -fr /var/cache && \
+    ostree container commit
 
 RUN systemctl enable rhsmcertd.service
 # Patching qemu backed binfmt configurations to use the actual executable's permissions and not the interpreter's

--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -1,6 +1,9 @@
 package verify
 
 import (
+	"os"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -97,23 +100,32 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(sshSession.outputToString()).To(And(ContainSubstring("ip_tables"), ContainSubstring("ip6_tables")))
 
 		// set by podman-rpm-info-vars.sh
+		if version := os.Getenv("PODMAN_VERSION"); version != "" {
+			// When we have an rc package fedora uses "~rc" while the upstream version is "-rc".
+			// As such we have to replace it so we can match the real version below.
+			version = strings.ReplaceAll(version, "~", "-")
+			// version is x.y.z while image uses x.y, remove .z so we can match
+			imageVersion := version
+			index := strings.LastIndex(version, ".")
+			if index >= 0 {
+				imageVersion = version[:index]
+			}
+			// verify the rpm-ostree image inside uses the proper podman image reference
+			sshSession, err = mb.setCmd([]string{"machine", "ssh", machineName, "sudo rpm-ostree status --json | jq -r '.deployments[0].\"container-image-reference\"'"}).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sshSession).To(Exit(0))
+			Expect(sshSession.outputToString()).
+				To(Equal("ostree-remote-image:fedora:docker://quay.io/podman/machine-os:" + imageVersion))
 
-		// TODO: there is no 5.5 in the copr yet as podman main would need to be bumped.
-		// But in order to do that it needs working machine images, catch-22.
-		// Skip this check for now, we should consider only doing this check on release branches.
-		// if version := os.Getenv("PODMAN_VERSION"); version != "" {
-		// 	// version is x.y.z while image uses x.y, remove .z so we can match
-		// 	index := strings.LastIndex(version, ".")
-		// 	if index >= 0 {
-		// 		version = version[:index]
-		// 	}
-		// 	// verify the rpm-ostree image inside uses the proper podman image reference
-		// 	sshSession, err = mb.setCmd([]string{"machine", "ssh", machineName, "sudo rpm-ostree status --json | jq -r '.deployments[0].\"container-image-reference\"'"}).run()
-		// 	Expect(err).ToNot(HaveOccurred())
-		// 	Expect(sshSession).To(Exit(0))
-		// 	Expect(sshSession.outputToString()).
-		// 		To(Equal("ostree-remote-image:fedora:docker://quay.io/podman/machine-os:" + version))
-		// }
+			// TODO: there is no 5.5 in the copr yet as podman main would need to be bumped.
+			// But in order to do that it needs working machine images, catch-22.
+			// Skip this check for now, we should consider only doing this check on release branches.
+			// check the server version so we know we have the right version installed in the VM
+			// server, err := mb.setCmd([]string{"version", "--format", "{{.Server.Version}}"}).run()
+			// Expect(err).ToNot(HaveOccurred())
+			// Expect(server).To(Exit(0))
+			// Expect(server.outputToString()).To(Equal(version))
+		}
 	})
 
 	It("machine stop/start cycle", func() {


### PR DESCRIPTION
see commits, fixes the missing exit code checks in the rpm-ostree install of podman that caused https://github.com/containers/podman-machine-os/issues/75 to go unnoticed

```release-note
None
```
