### PR TITLE
[v5.4] fix broken podman version

### DIFF
--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -48,13 +48,14 @@ RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
         --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
         aardvark-dns crun netavark podman containers-common containers-common-extra crun-wasm; \
     else \
-        rm /etc/yum.repos.d/rhcontainerbot*.repo /etc/pki/rpm-gpg/rhcontainerbot*.gpg; \
+        rm /etc/yum.repos.d/rhcontainerbot*.repo /etc/pki/rpm-gpg/rhcontainerbot*.gpg && \
         if [[ $(rpm -q podman) != "podman-${PODMAN_VERSION}-${PODMAN_RPM_RELEASE}.fc${FEDORA_RELEASE}.${ARCH}" ]]; then \
             rpm-ostree override replace ${PODMAN_RPM_URL}; \
-        fi; \
-    fi; \
-    rpm-ostree override remove moby-engine containerd runc; \
-    rm -fr /var/cache && ostree container commit
+        fi \
+    fi && \
+    rpm-ostree override remove moby-engine containerd runc && \
+    rm -fr /var/cache && \
+    ostree container commit
 
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -61,7 +61,9 @@ RUN if [[ ${PODMAN_RPM_TYPE} == "dev" ]]; then \
 # Install qemu-user-static for bootc
 # Install gvisor-tap-vsock-gvforwarder for hyperv
 # Install ansible for post-install configuration
-RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static ansible-core && rm -fr /var/cache
+RUN rpm-ostree install subscription-manager gvisor-tap-vsock-gvforwarder qemu-user-static ansible-core && \
+    rm -fr /var/cache && \
+    ostree container commit
 
 RUN systemctl enable rhsmcertd.service
 # Patching qemu backed binfmt configurations to use the actual executable's permissions and not the interpreter's

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -7,5 +7,5 @@ export PODMAN_RPM_TYPE="release"
 # PODMAN_VERSION is used for fetching the right rpm when PODMAN_RPM_TYPE is set to release.
 # However it is always used to derive the machine-os image tag (x.y) so this must be valid
 # at any given time.
-export PODMAN_VERSION="5.4.0-rc2"
+export PODMAN_VERSION="5.4.0~rc2"
 export PODMAN_RPM_RELEASE="1"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the 5.4 image to contain podman 5.4.0~rc2 inside instead of 5.3.1.
```
