### PR TITLE
update to v5.4.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,8 @@ env:
     # Vars used for the macos and windows testing
     MACHINE_IMAGE_BASE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/"
     # podman version used by windows/macos verify suite
-    PODMAN_INSTALL_VERSION: 5.4.0-rc2
+    # 5.4.1 is missing the windows installer right now
+    PODMAN_INSTALL_VERSION: 5.4.0
 
 gcp_credentials: ENCRYPTED[b06ef3490b73469d9da1402568d6f3e46a852955a4ab0807689d50352ecf2852cb5903e8d3b7603eaab9d1c7c7d851a5]
 

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -7,5 +7,5 @@ export PODMAN_RPM_TYPE="release"
 # PODMAN_VERSION is used for fetching the right rpm when PODMAN_RPM_TYPE is set to release.
 # However it is always used to derive the machine-os image tag (x.y) so this must be valid
 # at any given time.
-export PODMAN_VERSION="5.4.0"
+export PODMAN_VERSION="5.4.1"
 export PODMAN_RPM_RELEASE="1"


### PR DESCRIPTION
Note as there is no windows installer we cannot use that version to test, but that should not be a big deal.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
5.4.1 release
```
