### PR TITLE
pin coreos version to 41.20250215.3.0

### DIFF
--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/fedora/fedora-coreos:stable
+# The next version 41.20250302.3.2 started shipping kernel 6.13 and that
+# breaks rosetta. Pin the version for now to avoid releasing broken images.
+FROM quay.io/fedora/fedora-coreos:41.20250215.3.0
 
 ARG PODMAN_PR_NUM=${PODMAN_PR_NUM}
 


### PR DESCRIPTION
On applehv the rosetta implementation got broken by the new kernel 6.13 update.

AFAICT the rosetta issue is caused by kernel commit 4e6e8c2b757f ("binfmt_elf: Wire up AT_HWCAP3 at AT_HWCAP4") which added a new auxillary vector type. That results in the following rosetta error when trying to launch any x86_64 executables:
rosetta error: unhandled auxillary vector type 29

For now pin the version so we don't break our CI because of this and users can keep using the image with rosetta.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
pin coreos version to 41.20250215.3.0 due rosetta problem
```
