### PR TITLE
verify: add emulation test

### DIFF
--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("run basic podman commands", func() {
 	It("Basic ops", func() {
-		imgName := "docker.io/library/alpine"
+		imgName := "quay.io/libpod/testimage:20241011"
 		machineName, session, err := mb.initNowWithName()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -23,7 +23,7 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(pullSession).To(Exit(0))
 
 		// Check Images
-		checkCmd := []string{"images", "--format", "{{.Repository}}"}
+		checkCmd := []string{"images", "--format", "{{.Repository}}:{{.Tag}}"}
 		checkImages, err := mb.setCmd(checkCmd).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkImages).To(Exit(0))


### PR DESCRIPTION
verify: use our testimage

We have no control over the docker image so it could break us at
unexpected times. More importantly docker hub has strict rate limts so
it is possible that it will cause flakes in our CI runners.

quay.io is also known to be flaky but it should be better than running
in rate limits. If flakes become an issue we should consider keeping a
copy of the image in the repo and load it instead of pulling.

---

verify: add emulation test

So we know emulation setup in the machine image works as expected.


```release-note
None
```
