### PR TITLE
Bump to v5.4.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,7 @@ env:
     # Vars used for the macos and windows testing
     MACHINE_IMAGE_BASE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/"
     # podman version used by windows/macos verify suite
-    # 5.4.1 is missing the windows installer right now
-    PODMAN_INSTALL_VERSION: 5.4.0
+    PODMAN_INSTALL_VERSION: 5.4.2
 
 gcp_credentials: ENCRYPTED[b06ef3490b73469d9da1402568d6f3e46a852955a4ab0807689d50352ecf2852cb5903e8d3b7603eaab9d1c7c7d851a5]
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20250131t121915z-f41f40d13"
+    IMAGE_SUFFIX: "c20250324t111922z-f41f40d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/fedora/fedora-coreos:stable
+# The next version 41.20250302.3.2 started shipping kernel 6.13 and that
+# breaks rosetta. Pin the version for now to avoid releasing broken images.
+FROM quay.io/fedora/fedora-coreos:41.20250215.3.0
 
 ARG PODMAN_RPM_TYPE=${PODMAN_RPM_TYPE}
 ARG PODMAN_VERSION=${PODMAN_VERSION}

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -7,5 +7,5 @@ export PODMAN_RPM_TYPE="release"
 # PODMAN_VERSION is used for fetching the right rpm when PODMAN_RPM_TYPE is set to release.
 # However it is always used to derive the machine-os image tag (x.y) so this must be valid
 # at any given time.
-export PODMAN_VERSION="5.4.1"
+export PODMAN_VERSION="5.4.2"
 export PODMAN_RPM_RELEASE="1"

--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("run basic podman commands", func() {
 	It("Basic ops", func() {
-		imgName := "docker.io/library/alpine"
+		imgName := "quay.io/libpod/testimage:20241011"
 		machineName, session, err := mb.initNowWithName()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -23,7 +23,7 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(pullSession).To(Exit(0))
 
 		// Check Images
-		checkCmd := []string{"images", "--format", "{{.Repository}}"}
+		checkCmd := []string{"images", "--format", "{{.Repository}}:{{.Tag}}"}
 		checkImages, err := mb.setCmd(checkCmd).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkImages).To(Exit(0))


### PR DESCRIPTION
Backport some changes as well, most notably we need to pin coreos to the rosetta bug and add some test changes for that to double check emulation is working.


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
v5.4.2 release
```
