### PR TITLE
Use rpm-ostree rechunk to shrink image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,9 @@ podman build -t "${FULL_IMAGE_NAME_ARCH}" -f podman-image/Containerfile "${PWD}"
     --build-arg PODMAN_PR_NUM="${PODMAN_PR_NUM}" \
     --build-arg FEDORA_VERSION="${FEDORA_VERSION}"
 
+# Use rpm-ostree rechunk to remove unwanted data/packages and save space where can
+rpm-ostree compose build-chunked-oci --bootc --from "${FULL_IMAGE_NAME_ARCH}" --output containers-storage:"${FULL_IMAGE_NAME_ARCH}"
+
 echo "Saving image from image store to filesystem"
 
 mkdir -p "$OUTDIR"


### PR DESCRIPTION
rpm-ostree chunk should allow us to purge unneeded layers/packages in our base image file.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
