### PR TITLE
add email notifications for failed runs on branches

### DIFF
--- a/.github/workflows/cirrus_status.yml
+++ b/.github/workflows/cirrus_status.yml
@@ -1,8 +1,10 @@
 ---
 
 # Use the latest published version of the cirrus-ci_retrospective container
-# to determine the execution context of _this_ workflow run.  If it is a
-# pull request, post the artifact URLs so it is easy to download and test.
+# to determine the execution context of _this_ workflow run.
+# Inspect the cirrus status so we can post comments on PRs for build to allow
+# easy access to image downloads.
+# For CI runs on the branches send an email notification when the build failed.
 
 on:
     check_suite:  # ALWAYS triggered from the default branch
@@ -11,14 +13,10 @@ on:
             - completed
 
 jobs:
-    comment_image_id:
+    cirrus_notification:
         # Do not execute for other github applications, only works with cirrus-ci
         if: github.event.check_suite.app.name == 'Cirrus CI'
         runs-on: ubuntu-latest
-        env:
-            # This is the last component of the gist URL
-            # i.e. https://gist.github.com/<user>/<id>
-            built_images_gist_id: f505b6fb78db279855862e035629f8aa
         steps:
             - name: Execute latest upstream cirrus-ci_retrospective
               uses: docker://quay.io/libpod/cirrus-ci_retrospective:latest
@@ -42,27 +40,30 @@ jobs:
                   status=$(jq --raw-output \
                         '.[] | select(.name == "Total Success") | .status' \
                         "$ccirjson")
+                  branch=$(jq --raw-output \
+                        '.[] | select(.name == "Total Success") | .branch' \
+                        "$ccirjson")
 
                   if [[ -n "$prn" ]] && \
                      [[ "$prn" != "null" ]] && \
-                     [[ $prn -gt 0 ]] && \
-                     [[ "$status" == "COMPLETED" ]]
+                     [[ $prn -gt 0 ]]
                   then
                       printf "prn=%s\n" "$prn" >> $GITHUB_OUTPUT
-                      printf "bid=%s\n" "$bid" >> $GITHUB_OUTPUT
                       printf "is_pr=%s\n" "true" >> $GITHUB_OUTPUT
                   else
                       printf "prn=%s\n" "0" >> $GITHUB_OUTPUT
-                      printf "bid=%s\n" "0" >> $GITHUB_OUTPUT
                       printf "is_pr=%s\n" "false" >> $GITHUB_OUTPUT
                   fi
+                  printf "bid=%s\n" "$bid" >> $GITHUB_OUTPUT
+                  printf "status=%s\n" "$status" >> $GITHUB_OUTPUT
+                  printf "branch=%s\n" "$branch" >> $GITHUB_OUTPUT
 
-            - if: steps.retro.outputs.is_pr == 'true'
+            - if: steps.retro.outputs.is_pr == 'true' && steps.retro.outputs.status == 'COMPLETED'
               uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
-            - if: steps.retro.outputs.is_pr == 'true'
+            - if: steps.retro.outputs.is_pr == 'true' && steps.retro.outputs.status == 'COMPLETED'
               name: Print Artifacts output
               id: artifact_output
               run: |
@@ -70,7 +71,7 @@ jobs:
                   ./contrib/cirrus/print-artifacts-urls.sh "${{ steps.retro.outputs.bid }}" >> $GITHUB_OUTPUT
                   echo 'EOF' >> $GITHUB_OUTPUT
 
-            - if: steps.retro.outputs.is_pr == 'true'
+            - if: steps.retro.outputs.is_pr == 'true' && steps.retro.outputs.status == 'COMPLETED'
               name: Send GitHub PR comment
               uses: thollander/actions-comment-pull-request@v3
               with:
@@ -79,3 +80,19 @@ jobs:
                   comment-tag: artifacts
                   mode: recreate
                   message: "${{ steps.artifact_output.outputs.comment }}"
+
+            # Send mail on build failures that do not happen on PRs so we know if something fails.
+            # TODO: switch to "!= 'COMPLETED'", for now like this so I can test it once post merge.
+            - if: steps.retro.outputs.is_pr == 'false' && steps.retro.outputs.status == 'COMPLETED'
+              name: Email on build failures for branches
+              # Ref: https://github.com/dawidd6/action-send-mail
+              uses: dawidd6/action-send-mail@v3.12.0
+              with:
+                server_address: ${{secrets.ACTION_MAIL_SERVER}}
+                server_port: 465
+                username: ${{secrets.ACTION_MAIL_USERNAME}}
+                password: ${{secrets.ACTION_MAIL_PASSWORD}}
+                subject: Cirrus-CI cron build failures on ${{github.repository}}
+                to: "podman-monitor@lists.podman.io"
+                from: ${{secrets.ACTION_MAIL_SENDER}}
+                body: "podman-machine-os build failed on branch ${{ steps.retro.outputs.branch }}: https://cirrus-ci.com/build/${{ steps.retro.outputs.bid }}"


### PR DESCRIPTION
So that we now when something is not right outside of PRs. We are reusing the same action as it uses the same trigger and we must inspect the cirrus ci_retrospective anyway to get the data we want. So rename the action to be more descriptive and add steps to send the email on failures.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
