### PR TITLE
push next tag for images build on main

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -182,6 +182,10 @@ publish_images_task:
         podman images
         podman login -u "$QUAY_USER" --password-stdin quay.io <<<"$QUAY_PASSWORD"
         time podman manifest push --all "$FULL_IMAGE_NAME"
+        if [[ "$CIRRUS_BRANCH" == "main" ]]; then
+            # When running on main push a "next" tag as well.
+            time podman manifest push --all "$FULL_IMAGE_NAME" "${FULL_IMAGE_NAME%:*}:next"
+        fi
     release_script: |
         if [[ $CIRRUS_TAG != '' ]]; then
             pushd $OUTDIR

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ env:
     # Vars used for the macos and windows testing
     MACHINE_IMAGE_BASE_URL: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/image_build/image/"
     # podman version used by windows/macos verify suite
-    PODMAN_INSTALL_VERSION: 5.5.0-rc1
+    PODMAN_INSTALL_VERSION: 5.5.0
 
 gcp_credentials: ENCRYPTED[b06ef3490b73469d9da1402568d6f3e46a852955a4ab0807689d50352ecf2852cb5903e8d3b7603eaab9d1c7c7d851a5]
 


### PR DESCRIPTION
To allow easier testing by others always publish a next tag for the
image on main. This means that users don't need to be aware of when we
branch and update to the next version as they can just always track
next.

Fixes #126

```release-note
Publish a next tag for the machine-os image which always points to the most recently build image on main.
```
