### PR TITLE
fix: inactive network-online.target

### DIFF
--- a/podman-image/Containerfile
+++ b/podman-image/Containerfile
@@ -98,3 +98,6 @@ RUN --network=none rm -vf /etc/resolv.conf && rpm -e systemd-resolved
 # https://github.com/containers/podman/pull/21670#discussion_r1585790802
 COPY rosetta-activation.service /etc/systemd/system/rosetta-activation.service
 COPY rosetta-activation.sh /usr/local/bin/rosetta-activation.sh
+
+# By default nothing is pulling the network-online.target so it does not get activated
+RUN ln -s /usr/lib/systemd/system/network-online.target /etc/systemd/system/multi-user.target.wants/network-online.target

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -182,5 +182,12 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			// Expect(server).To(Exit(0))
 			// Expect(server.outputToString()).To(Equal(version))
 		})
+		It("should have podman-user-wait-network-online.service active", func() {
+			cmd := []string{"machine", "ssh", machineName, "systemctl", "--user", "-P", "ActiveState", "show", "podman-user-wait-network-online.service"}
+			session, err := mb.setCmd(cmd).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session).To(Exit(0))
+			Expect(session.outputToString()).To(Equal("active"))
+		})
 	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

Trying to apply suggestion from https://github.com/containers/podman/issues/26134#issuecomment-2897868842

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
ensure `network-online.target` is active for user
```
