### PR TITLE
Use temporary base image

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -52,5 +52,5 @@ export FULL_IMAGE_NAME_ARCH="$FULL_IMAGE_NAME-${ARCH_TO_IMAGE_ARCH[$CPU_ARCH]}"
 
 # The next version 41.20250302.3.2 started shipping kernel 6.13 and that
 # breaks rosetta. Pin the version for now to avoid releasing broken images.
-FCOS_BASE_IMAGE="quay.io/fedora/fedora-coreos:41.20250215.3.0"
+FCOS_BASE_IMAGE="quay.io/podman/fcos:41.20250215.3.0"
 export FCOS_BASE_IMAGE


### PR DESCRIPTION
Because our pinned base image version was pruned from Quay, I have made a temporary image from their OCI archives.  These are pushed to quay.io/podman/fcos:pinned_version.  Once/if the Rosetta problem is resolved, we can update to the latest base version.


<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
