### PR TITLE
build: mount rpm dir in container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,10 +19,11 @@ esac
 FEDORA_VERSION="f"$(podman run --rm "$FCOS_BASE_IMAGE" rpm --eval '%{?fedora}')
 export FEDORA_VERSION
 
+mkdir -p ./rpms
+
 # Don't fail if koji download-build can't find any rpms
 set +e
 if [[ ${PODMAN_PR_NUM} != "" ]]; then
-    mkdir -p ./rpms
     pushd ./rpms
     for pkg in container-selinux crun;
     do
@@ -54,7 +55,7 @@ set -e
 # See podman-rpm-info-vars.sh for all build-arg values. If PODMAN_PR_NUM is
 # empty, the rpm version, release and fedora release values are of no concern
 # to the build process.
-podman build -t "${FULL_IMAGE_NAME_ARCH}" -f podman-image/Containerfile "${PWD}"/podman-image \
+podman build -t "${FULL_IMAGE_NAME_ARCH}" -v "$PWD"/rpms:/var/tmp/rpms -f podman-image/Containerfile "${PWD}"/podman-image \
     --build-arg FCOS_BASE_IMAGE="${FCOS_BASE_IMAGE}" \
     --build-arg PODMAN_PR_NUM="${PODMAN_PR_NUM}" \
     --build-arg FEDORA_VERSION="${FEDORA_VERSION}"


### PR DESCRIPTION
The dir containing the rpms downloaded from koji need to be mounted in the container for the dependency update to work.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
