### PR TITLE
fix publish task for wsl

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -207,7 +207,7 @@ publish_images_task:
         fi
     push_script: |
         mkdir $OUTDIR
-        for end in applehv.raw.zst hyperv.vhdx.zst qemu.qcow2.zst tar; do
+        for end in applehv.raw.zst hyperv.vhdx.zst qemu.qcow2.zst wsl.tar.zst tar; do
             for arch in x86_64 aarch64; do
                 name="podman-machine.$arch.$end"
                 curl --retry 5 --retry-delay 8 --fail --location -O --output-dir $OUTDIR --url "${MACHINE_IMAGE_BASE_URL}$name"


### PR DESCRIPTION
I missed to update the publish task to download the new wsl builds. One of the downsides with post merge tasks only.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
