### PR TITLE
image: fix podman-user-wait-network-online.service

### DIFF
--- a/podman-image/Containerfile.COREOS
+++ b/podman-image/Containerfile.COREOS
@@ -9,6 +9,9 @@ RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \
 
 COPY podman-iptables.conf /etc/modules-load.d/podman-iptables.conf
 
+# Work around for network-online.target issue https://github.com/containers/podman/issues/26134
+COPY podman-user-wait-network-online-override.conf /usr/lib/systemd/user/podman-user-wait-network-online.service.d/podman-user-wait-network-online-override.conf
+
 ## Enables automatic login on the console;
 ## there's no security concerns here, and this makes debugging easier.
 ## xref https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-autologin/

--- a/podman-image/podman-user-wait-network-online-override.conf
+++ b/podman-image/podman-user-wait-network-online-override.conf
@@ -1,0 +1,7 @@
+[Service]
+# Unset main ExecStart which tries to poll network-online.target but if nothing actives that as root then
+# this is broken: https://github.com/containers/podman/issues/26134
+# For podman machine we know we are using NetworkManager so we can just call this command directly here.
+ExecStart=
+ExecStart=/usr/bin/nm-online -s -q
+Environment=NM_ONLINE_TIMEOUT=60

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -65,6 +65,22 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			Expect(maxUserInstancesSession).To(Exit(0))
 			Expect(maxUserInstancesSession.outputToString()).To(ContainSubstring("fs.inotify.max_user_instances = 524288"))
 		})
+
+		It("podman-user-wait-network-online.service works", func() {
+			skipIfVmtype(WSLVirt, "no network manager in WSL")
+
+			cmd := []string{"machine", "ssh", machineName, "systemctl", "--user", "start", "podman-user-wait-network-online.service"}
+			session, err := mb.setCmd(cmd).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session).To(Exit(0))
+
+			cmd = []string{"machine", "ssh", machineName, "systemctl", "--user", "-P", "ActiveState", "show", "podman-user-wait-network-online.service"}
+			session, err = mb.setCmd(cmd).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session).To(Exit(0))
+			Expect(session.outputToString()).To(Equal("active"))
+		})
+
 		It("should apply the `10-autologin.conf` successfully", func() {
 			skipIfVmtype(WSLVirt, "no tty for WSL")
 			autologinArgv := "argv[]=/usr/sbin/agetty --autologin root --noclear ttyS0 $TERM"


### PR DESCRIPTION
The main issue is that if network-online.target is not active as root then polling for it as rootless will always fail. By default on coreos nothing pulls in network-online.target so the service never is triggered. This then causes problem for the rootless quadlet units.

Because we know we are always using NetworkManager we can just use their online command directly from a rootless user to fix this.

Fixes: containers/podman#26134

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman-user-wait-network-online.service should now work correctly inside the machine
```
