### PR TITLE
CI: include wsl version info

### DIFF
--- a/contrib/cirrus/win-verify.ps1
+++ b/contrib/cirrus/win-verify.ps1
@@ -4,6 +4,9 @@ Import-CLIXML "$ENV:TEMP\envars.xml" | % {
     Set-Item "Env:$($_.Name)" "$($_.Value)"
 }
 
+# Output info so we know what version we are testing.
+wsl --version
+
 $Env:CONTAINERS_MACHINE_PROVIDER = "${ENV:PROVIDER}"
 $Env:MACHINE_IMAGE_PATH="..\${ENV:MACHINE_IMAGE}"
 .\bin\ginkgo -v .\verify


### PR DESCRIPTION
So we know what we are actually testing CI and can compare it to the local setup to reproduce things.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
