### PR TITLE
podman-next: pin crun version

### DIFF
--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -67,8 +67,9 @@ EOF
 if [[ ${PODMAN_PR_NUM} == "" ]]; then \
     curl --fail -o /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repo
     curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg
+    dnf install -y crun-1.21-1.20250612195640314612.main.198.gd89542c6.fc42 crun-1.21-1.20250612195640314612.main.198.gd89542c6.fc42
     dnf install --best -y \
-    aardvark-dns crun netavark podman containers-common containers-common-extra crun-wasm
+    aardvark-dns netavark podman containers-common containers-common-extra
 else
     shopt -s nullglob
     FILE="/var/tmp/rpms/*.rpm"


### PR DESCRIPTION
The latest podman-next crun causes issues on WSL.

Ref: https://github.com/containers/crun/issues/1797

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
