### PR TITLE
cirrus: only send email when there is an actual error

### DIFF
--- a/.github/workflows/cirrus_status.yml
+++ b/.github/workflows/cirrus_status.yml
@@ -98,5 +98,6 @@ jobs:
                 password: ${{secrets.ACTION_MAIL_PASSWORD}}
                 subject: Cirrus-CI build failures on ${{github.repository}}
                 to: "podman-monitor@lists.podman.io"
+                reply_to: "podman-monitor@lists.podman.io"
                 from: ${{secrets.ACTION_MAIL_SENDER}}
                 body: "podman-machine-os build failed on branch ${{ steps.retro.outputs.branch }}: https://cirrus-ci.com/build/${{ steps.retro.outputs.bid }}"

--- a/.github/workflows/cirrus_status.yml
+++ b/.github/workflows/cirrus_status.yml
@@ -38,7 +38,7 @@ jobs:
                         '.[] | select(.name == "Total Success") | .build.id' \
                         "$ccirjson")
                   status=$(jq --raw-output \
-                        '.[] | select(.name == "Total Success") | .status' \
+                        '.[] | select(.name == "Total Success") | .build.status' \
                         "$ccirjson")
                   branch=$(jq --raw-output \
                         '.[] | select(.name == "Total Success") | .build.branch' \
@@ -82,7 +82,12 @@ jobs:
                   message: "${{ steps.artifact_output.outputs.comment }}"
 
             # Send mail on build failures that do not happen on PRs so we know if something fails.
-            - if: steps.retro.outputs.is_pr == 'false' && steps.retro.outputs.status != 'COMPLETED'
+            # BuildStatus enum is defined in https://github.com/cirruslabs/cirrus-ci-web/blob/master/schema.gql
+            - if: |
+                steps.retro.outputs.is_pr == 'false' &&
+                ( steps.retro.outputs.status == 'FAILED' ||
+                  steps.retro.outputs.status == 'ABORTED' ||
+                  steps.retro.outputs.status == 'ERRORED' )
               name: Email on build failures for branches
               # Ref: https://github.com/dawidd6/action-send-mail
               uses: dawidd6/action-send-mail@v3.12.0


### PR DESCRIPTION
For some reason sometimes the github action triggers prematurely
multiple times. And then we got several emails saying there is a failure
when there wasn't one. This is because the task status was still at
"CREATED".

To fix this only check the overall build status field not the task status
of "Total Success". And then update our condition to only match for
actual error status messages and ignore other ones.

This should prevent us from getting these false positves emails.

```release-note
None
```
