### PR TITLE
Add "latest" logic to automated releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -227,10 +227,26 @@ publish_images_task:
             popd
 
             gh auth login --with-token <<<"$RELEASE_TOKEN"
+
+            if [[ $CIRRUS_TAG == *-rc* ]]; then
+                RC="--prerelease"
+            else
+                # check if this version should not be marked latest
+                prevvers=$(gh api repos/containers/podman-machine-os/releases/latest --jq '.tag_name')
+                echo "${prevvers},${CIRRUS_TAG}"
+                # sort -V -C returns 0 if args are ascending version order
+                if !(echo "${prevvers},${CIRRUS_TAG}" | tr ',' '\n' | sort -V -C)
+                then
+                    LATEST="--latest=false"
+                fi
+            fi
+
             gh release create $CIRRUS_TAG \
                 -t $CIRRUS_TAG \
                 --notes "$CIRRUS_TAG release images" \
                 --verify-tag \
+                $RC \
+                $LATEST \
                 $OUTDIR/*
             gh auth logout
         fi


### PR DESCRIPTION
RC's should be marked as pre-release, and latest should be the highest semantic version
Fixes: https://github.com/containers/podman-machine-os/issues/162

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
