### PR TITLE
feat: Add support for running qemu-guest-agent in machine

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -exo pipefail
 

--- a/podman-image/Containerfile.COREOS
+++ b/podman-image/Containerfile.COREOS
@@ -40,3 +40,16 @@ RUN --network=none rm -vf /etc/resolv.conf && rpm -e systemd-resolved
 # https://github.com/containers/podman/pull/21670#discussion_r1585790802
 COPY rosetta-activation.service /etc/systemd/system/rosetta-activation.service
 COPY rosetta-activation.sh /usr/local/bin/rosetta-activation.sh
+
+# Configure qemu-guest-agent
+# Copy in our service file override that communicates over vsock
+COPY qemu-guest-agent.service /etc/systemd/system/qemu-guest-agent.service
+# Bind mount non-base selinux policy module compile it and install it to allow
+# qemu-guest-agent access to the vsock-socket
+RUN --mount=type=bind,source=/qemuga-vsock.te,target=/run/qemuga-vsock.te,z <<EOF
+/usr/bin/checkmodule -M -m -o /run/qemuga-vsock.mod /run/qemuga-vsock.te
+/usr/bin/semodule_package -o /run/qemuga-vsock.pp -m /run/qemuga-vsock.mod
+sudo semodule -i /run/qemuga-vsock.pp
+rm /run/qemuga-vsock.pp /run/qemuga-vsock.mod
+systemctl enable qemu-guest-agent.service
+EOF

--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -105,6 +105,10 @@ PACKAGES=(
 
     # cpp for buildah.in support
     cpp
+
+    # qemu-guest-agent to enable communication from the host
+    qemu-guest-agent
+    checkpolicy
 )
 
 dnf install -y "${PACKAGES[@]}"

--- a/podman-image/qemu-guest-agent.service
+++ b/podman-image/qemu-guest-agent.service
@@ -1,0 +1,11 @@
+Description=QEMU Guest Agent
+IgnoreOnIsolate=True
+
+[Service]
+UMask=0077
+ExecStart=/usr/bin/qemu-ga --method=vsock-listen --path=3:1025 # Todo: The 3 may need to be dynamic
+Restart=always
+RestartSec=0
+
+[Install]
+WantedBy=default.target

--- a/podman-image/qemuga-vsock.te
+++ b/podman-image/qemuga-vsock.te
@@ -1,0 +1,9 @@
+module qemuga-vsock 1.0;
+
+require {
+        type virt_qemu_ga_t;
+        class vsock_socket { bind create getattr listen accept read write };
+}
+
+#============= virt_qemu_ga_t ==============
+allow virt_qemu_ga_t self:vsock_socket { bind create getattr listen accept read write };


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for running qemu-guest-agent in machine
```
