### PR TITLE
disable zincati OCI backend warning in MOTD

### DIFF
--- a/podman-image/00-podman-machine.preset
+++ b/podman-image/00-podman-machine.preset
@@ -3,6 +3,9 @@
 # Disable Root mountpoint warning on shh login
 # https://github.com/containers/podman-machine-os/issues/155
 disable coreos-warn-invalid-mounts.service
+# We don't use zincati but because we ship our own custom builds so
+# we don't care about the coreos update migration to OCI images.
+disable coreos-oci-migration-motd.service
 
 # Disable coreos chrony config, we do provide our own.
 disable coreos-platform-chrony-config.service

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -160,6 +160,8 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			output := sshSession.outputToString()
 			Expect(output).To(ContainSubstring("Fedora CoreOS"), "should contain FCOS motd message")
 			Expect(output).ToNot(ContainSubstring("Warning"), "no warnings in motd message seen")
+			// no coreos-oci-migration-motd.service output should be seen
+			Expect(output).ToNot(ContainSubstring("zincati"), "no zincati migrate wanring in motd message seen")
 		})
 
 		It("check systemd resolved is not in use", func() {


### PR DESCRIPTION
We don't use that as we ship our own custom images as such this should be disabled to not confuse our users.

The following output is printed right now:

  The zincati service is disabled on this system.
  If not done so already please migrate the system to the OCI backend
  for updates by running:

  stream=stable # or testing or next
  target=ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:$stream
  sudo rpm-ostree rebase $target --reboot

  Where $stream matches the Fedora CoreOS stream the system is following.

  To disable this warning, use:
  sudo systemctl disable coreos-oci-migration-motd.service

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
