### PR TITLE
Revert "cirrus: enable Spot instances for EC2 tasks"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,7 +42,6 @@ image_build_task:
         type: "${EC2_INST_TYPE}"
         region: us-east-1
         architecture: "${GO_ARCH}"
-        spot: true
     env:
         HOME: /root
     matrix:
@@ -78,7 +77,6 @@ verify_linux_task:
         type: "${EC2_INST_TYPE}"
         region: us-east-1
         architecture: "${GO_ARCH}"
-        spot: true
     env:
         HOME: /root
         MACHINE_IMAGE: "podman-machine.${ARCH}.qemu.qcow2.zst"
@@ -109,7 +107,6 @@ verify_windows_task:
         type: m5zn.metal
         region: us-east-1
         platform: windows
-        spot: true
     env:
         ARCH: "x86_64"
         CIRRUS_WORKING_DIR: "${LOCALAPPDATA}\\cirrus-ci-build"
@@ -194,7 +191,6 @@ publish_images_task:
         image: "${VM_IMAGE}"
         type: "${EC2_INST_TYPE}"
         region: us-east-1
-        spot: true
     env:
         HOME: /root
         VM_IMAGE: "${FEDORA_AMI}"


### PR DESCRIPTION
address issues on spot instance : https://github.com/containers/podman-machine-os/issues/223
This reverts commit cc92ac124ea57df19ec61b5645d3ad01fa386095.
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
