### PR TITLE
remove rosetta disable work around

### DIFF
--- a/podman-image/rosetta-activation.service
+++ b/podman-image/rosetta-activation.service
@@ -1,12 +1,6 @@
 [Unit]
 Description=Activates Rosetta if necessary
 After=systemd-binfmt.service
-# Rosetta is not functional on kernel 6.13 or newer so we like to have it not
-# running so the VM uses qemu-user instead. While we could remove the unit I
-# prefer to keep it with a marker file as apple could ship a new rosetta
-# version anytime and then testing it should be quite simple by creating this
-# file without us having to rebuild the VM image.
-ConditionPathExists=/etc/containers/enable-rosetta
 ConditionVirtualization=apple
 ConditionArchitecture=arm64
 

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -111,7 +111,6 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			Expect(subscriptionManagerSession.outputToString()).To(Equal("loaded"))
 		})
 		It("should load Rosetta activation service", func() {
-			Skip("rosetta disabled as it doesn't work on newer kernels")
 			skipIfNotVmtype(AppleHvVirt, "Rosetta service is activated when the provider is applehv")
 			rosettaCmd := []string{"machine", "ssh", machineName, "systemctl", "-P", "ActiveState", "show", "rosetta-activation.service"}
 			rosettaSession, err := mb.setCmd(rosettaCmd).run()


### PR DESCRIPTION
Do not require an extra marker file, just let the client control if the unit is active or not[1].

Fixes: #212

[1] https://github.com/containers/container-libs/pull/798

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The special need for the /etc/containers/enable-rosetta marker file has been removed 
```
