### PR TITLE
adapt for podman 6 configs

### DIFF
--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-mkdir -p /etc/containers/registries.conf.d \
-         /etc/systemd/system.conf.d \
+mkdir -p /etc/systemd/system.conf.d \
          /etc/environment.d \
-         /etc/containers/registries.conf.d \
          /etc/ssh/sshd_config.d \
          /etc/sysctl.d \
          /etc/chrony.d \
-         /etc/systemd/system/user@.service.d
+         /etc/systemd/system/user@.service.d \
+         /usr/share/containers/containers.conf.d \
+         /usr/share/containers/registries.conf.d
 
 # Install config files
 
@@ -22,7 +22,7 @@ cat >/etc/profile.d/docker-host.sh <<'EOF'
 export DOCKER_HOST="unix://$(podman info -f "{{.Host.RemoteSocket.Path}}")"
 EOF
 
-cat >/etc/containers/registries.conf.d/999-podman-machine.conf <<EOF
+cat >/usr/share/containers/registries.conf.d/999-podman-machine.conf <<EOF
 # Issue #11489: make sure that we can inject a custom registries.conf
 # file on the system level to force a single search registry.
 # The remote client does not yet support prompting for short-name
@@ -30,6 +30,20 @@ cat >/etc/containers/registries.conf.d/999-podman-machine.conf <<EOF
 # as a workaround.
 
 unqualified-search-registries=["docker.io"]
+EOF
+
+cat >/usr/share/containers/containers.conf.d/999-podman-machine.conf <<EOF
+# Starting with Podman 6 we mount the host configs into the VM at /etc/containers, see
+# https://github.com/containers/podman/pull/28573
+#
+# The problem with that is that helper_binaries_dir has two purposes, finding client
+# binaries (i.e. gvproxy) but also the server ones (i.e. netavark). If a user sets this
+# to a client path they could unset the server default and thus make podman inside the
+# VM more or less unusable.
+# To fix this lets always append the fedora package path last here.
+
+[engine]
+helper_binaries_dir=["/usr/libexec/podman", {append=true}]
 EOF
 
 cat >/etc/sysctl.d/10-inotify-instances.conf <<EOF

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -189,6 +189,13 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			Expect(sshSession.outputToString()).To(And(ContainSubstring("ip_tables"), ContainSubstring("ip6_tables")))
 		})
 
+		It("verify custom podman config settings", func() {
+			sshSession, err := mb.setCmd([]string{"machine", "ssh", machineName, "cat", "/usr/share/containers/registries.conf.d/999-podman-machine.conf", "/usr/share/containers/containers.conf.d/999-podman-machine.conf"}).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sshSession).To(Exit(0))
+			Expect(sshSession.outputToString()).To(And(ContainSubstring("unqualified-search-registries"), ContainSubstring("helper_binaries_dir")))
+		})
+
 		It("check podman coreos image version", func() {
 			skipIfVmtype(WSLVirt, "wsl does not use ostree updates")
 			// set by podman-rpm-info-vars.sh


### PR DESCRIPTION
Move the custom configs we create into /usr because we like to overmount /etc/containers from the host side.

Also due the overmount it means we leak some client settings into the VM, the helper_binaries_dir path could cause problems. To prevent issues for users who have set helper_binaries_dir on client add a custom containers.conf which appends the fedora path last.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
