### PR TITLE
Make this a subproject of Podman Container Tools

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,3 @@
+## The Podman Project Community Code of Conduct
+
+The Podman project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,33 @@
+# Podman-machine-os Maintainers
+
+[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
+describes the Podman project's governance and the Project Roles used below.
+
+Please note that this file only includes the podman-machine-os subproject's Maintainers and Reviewers.
+Maintainers and Reviewers for the other subprojects are found in their respective repository's MAINTAINERS.md files.
+
+## Maintainers
+
+| Maintainer        | GitHub ID                                                | Project Roles     | Affiliation                                  |
+|-------------------|----------------------------------------------------------|-------------------|----------------------------------------------|
+| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
+| Mohan Boddu       | [mohanboddu](https://github.com/mohanboddu)              | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
+| Mario Loriedo     | [l0rd](https://github.com/l0rd/)                         | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
+| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
+| Tim Zhou          | [timcoding1988](https://github.com/timcoding1988)        | Reviewer          | [Red Hat](https://github.com/RedHatOfficial) |
+
+## Alumni
+
+There are currently no alumni.
+
+## Credits
+
+The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
This moves the podman-machine-os project - which builds VM images critical to the operation of the `podman machine` command - to be part of the Podman Container Tools CNCF project.

Preliminary voting was conducted in #245 with no objections.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
