### PR TITLE
set custom os-release variant and sideload nv/av

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,8 @@ mkdir -p "$OUTDIR"
     podman build --output type=tar,dest="$tarfile" \
     -f podman-image/Containerfile.WSL "${PWD}"/podman-image \
     --build-arg PODMAN_PR_NUM="${PODMAN_PR_NUM}" \
+    --build-arg NETAVARK_PR_NUM="${NETAVARK_PR_NUM}" \
+    --build-arg AARDVARK_DNS_PR_NUM="${AARDVARK_DNS_PR_NUM}" \
     --build-arg FEDORA_VERSION="${FEDORA_VERSION:1}"
 
     $ZSTD_CMD $tarfile
@@ -77,7 +79,9 @@ trap "kill %1 || true; echo; echo 'WSL build log:'; cat $WSL_LOG" EXIT
 podman build -t "${FULL_IMAGE_NAME_ARCH}" -v "$PWD"/rpms:/var/tmp/rpms \
     -f podman-image/Containerfile.COREOS "${PWD}"/podman-image \
     --build-arg FCOS_BASE_IMAGE="${FCOS_BASE_IMAGE}" \
-    --build-arg PODMAN_PR_NUM="${PODMAN_PR_NUM}"
+    --build-arg PODMAN_PR_NUM="${PODMAN_PR_NUM}" \
+    --build-arg NETAVARK_PR_NUM="${NETAVARK_PR_NUM}" \
+    --build-arg AARDVARK_DNS_PR_NUM="${AARDVARK_DNS_PR_NUM}"
 
 # Use rpm-ostree rechunk to remove unwanted data/packages and save space where can
 echo "Re-Chunking to make incremental upgrades more efficient"

--- a/podman-image/Containerfile.COREOS
+++ b/podman-image/Containerfile.COREOS
@@ -11,6 +11,8 @@ RUN dnf install -y checkpolicy policycoreutils && dnf clean all && \
 FROM ${FCOS_BASE_IMAGE}
 
 ARG PODMAN_PR_NUM=${PODMAN_PR_NUM}
+ARG NETAVARK_PR_NUM=${NETAVARK_PR_NUM}
+ARG AARDVARK_DNS_PR_NUM=${AARDVARK_DNS_PR_NUM}
 ARG FEDORA_VERSION=${FEDORA_VERSION}
 
 RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \

--- a/podman-image/Containerfile.WSL
+++ b/podman-image/Containerfile.WSL
@@ -2,6 +2,8 @@ ARG FEDORA_VERSION=${FEDORA_VERSION}
 FROM quay.io/fedora/fedora:${FEDORA_VERSION}
 
 ARG PODMAN_PR_NUM=${PODMAN_PR_NUM}
+ARG NETAVARK_PR_NUM=${NETAVARK_PR_NUM}
+ARG AARDVARK_DNS_PR_NUM=${AARDVARK_DNS_PR_NUM}
 
 RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \
     /run/build_common.sh

--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -92,6 +92,13 @@ else
     dnf install --best -y podman
 fi
 
+curl --fail -o /etc/yum.repos.d/netavark-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/containers-netavark-${NETAVARK_PR_NUM}/repo/fedora-rawhide/packit-containers-netavark-${NETAVARK_PR_NUM}-fedora-rawhide.repo
+curl --fail -o /etc/pki/rpm-gpg/netavark-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/containers-netavark-${NETAVARK_PR_NUM}/pubkey.gpg
+curl --fail -o /etc/yum.repos.d/aardvark-dns-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}/repo/fedora-rawhide/packit-containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}-fedora-rawhide.repo
+curl --fail -o /etc/pki/rpm-gpg/aardvark-dns-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}/pubkey.gpg
+
+dnf install --best -y netavark aardvark-dns
+
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc/user emulation
 # Install device-mapper (this satisfies the deps for qemu-user-static

--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -99,6 +99,11 @@ fi
 dnf install -y --setopt=install_weak_deps=false \
     subscription-manager device-mapper qemu-user-static-aarch64 qemu-user-static-x86
 
+# Set a custom variant to mark this image as our own for both fedora countme
+# tracking and our own podman info output.
+# https://github.com/podman-container-tools/podman-machine-os/issues/253
+sed -i 's/VARIANT=.*/VARIANT="Podman Machine OS"/g' /usr/lib/os-release
+sed -i 's/VARIANT_ID=.*/VARIANT_ID=podman-machine-os/g' /usr/lib/os-release
 
 # Package list to install
 PACKAGES=(

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -7,3 +7,8 @@
 # 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/podman-next` copr.
 export PODMAN_VERSION="6.0.0-dev"
 export PODMAN_PR_NUM=""
+
+# Temporary work around due the fact that podman 6 needs the new nv/av 2.0 which is also not in
+# the fedora stable repos until f45
+export NETAVARK_PR_NUM="1464"
+export AARDVARK_DNS_PR_NUM="706"

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -225,6 +225,18 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			Expect(sshSession.outputToString()).To(And(ContainSubstring("unqualified-search-registries"), ContainSubstring("helper_binaries_dir")))
 		})
 
+		It("verify custom os-release variant", func() {
+			sshSession, err := mb.setCmd([]string{"machine", "ssh", machineName, "cat", "/etc/os-release"}).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sshSession).To(Exit(0))
+			Expect(sshSession.outputToString()).To(And(ContainSubstring(`VARIANT="Podman Machine OS"`), ContainSubstring(`VARIANT_ID=podman-machine-os`)))
+
+			archSession, err := mb.setCmd([]string{"info", "--format", "{{.Host.Distribution.Variant}}"}).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(archSession).To(Exit(0))
+			Expect(archSession.outputToString()).To(Equal("podman-machine-os"))
+		})
+
 		It("check podman coreos image version", func() {
 			skipIfVmtype(WSLVirt, "wsl does not use ostree updates")
 			// set by podman-rpm-info-vars.sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman machine os image now uses a custom variant in the os-release file
```
