### PR TITLE
ci: fix mkfs.xfs workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,13 @@ jobs:
       - name: Build images
         run: |
           # add custom xfs call to not create a fs that cannot be mounted on the older runner kernel
-          cat >/usr/local/bin/mkfs.xfs <<EOF
+          # For some reason /usr/local/bin is not being recognized by osbuild so replace the actual binary
+          mv /usr/bin/mkfs.xfs /usr/bin/mkfs.xfs.real
+          cat >/usr/bin/mkfs.xfs <<EOF
           #!/bin/bash
-          /usr/bin/mkfs.xfs -c options=/usr/share/xfsprogs/mkfs/lts_6.6.conf "\$@"
+          /usr/bin/mkfs.xfs.real -c options=/usr/share/xfsprogs/mkfs/lts_6.6.conf "\$@"
           EOF
-          chmod +x /usr/local/bin/mkfs.xfs
+          chmod +x /usr/bin/mkfs.xfs
 
           # add getenforce to claim we support selinux even when we do not
           # https://github.com/coreos/custom-coreos-disk-images/pull/30
@@ -56,6 +58,11 @@ jobs:
 
           ./build.sh
           mv $OUTDIR/podman-machine $OUTDIR/podman-machine.${{ matrix.os.arch }}.tar
+
+      # just for debugging, i.e. when mounting failed.
+      - name: dmesg
+        if: always()
+        run: dmesg
 
       # This is kinda annoying, we cannot upload all files as wildcards it then uploads all files in one zip.
       # Which then means users would need to download all files at once to test a single disk image.


### PR DESCRIPTION
/usr/local/bin/mkfs.xfs is for whatever reasons not being called by osbuild for some reason, as far as I can tell from the code there it should use $PATH fine.

Replace the binary in place to ensure we use the right workaround with the older fs options as otherwise the pipeline fails to mount the image.

As for why this only fails on aarch it seems that uses a much older kernel 6.8 vs 6.17 on x86_64 and the newer kernel seems to mount fine without the work around.

I don't know what exactly changed that it started to fail just now. I don't see an osbuild update that would explain it.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
