### PR TITLE
fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
               fi
           fi
 
-          gh release create $VERSION \
+          gh --repo "$REPO" release create $VERSION \
               -t $VERSION \
               --notes "$VERSION release images" \
               --verify-tag \


### PR DESCRIPTION
We need to include the repo location to the gh cli so it knows where to create the release because we do not have/need a repo checkout here.


