### PR TITLE
[v6.0] Switch from podman-next to f44-podman6 copr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some environment variables are set in `podman-rpm-info-vars.sh`:
 - `PODMAN_VERION`: used for the image tag (only the x.y, the patch version is
   ignored)
 - `PODMAN_PR_NUM`: used to add a podman version from a PR. The default is empty
-  (and rpms will be fetched from the `rhcontainerbot/podman-next` copr)
+  (and rpms will be fetched from the `rhcontainerbot/f44-podman6` copr)
 
 ## Running the tests
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ echo " Building image locally"
 
 # Validate PODMAN_PR_NUM var, see the Containerfile for the pull logic.
 case "${PODMAN_PR_NUM}" in
-  '') echo "Will install podman from the podman-next copr, the podman version is ignored" ;;
+  '') echo "Will install podman from the f44-podman6 copr, the podman version is ignored" ;;
   [0-9]*) ;;
   *) echo 'PODMAN_PR_NUM must be empty or set to a valid PR number' 1>&2; exit 1;;
 esac

--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -79,8 +79,8 @@ EOF
 # release agnostic and such `rawhide` URLs are unlikely to change compared to URLs
 # containing Fedora release numbers.
 if [[ ${PODMAN_PR_NUM} == "" ]]; then \
-    curl --fail -o /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repo
-    curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg
+    curl --fail -o /etc/yum.repos.d/rhcontainerbot-f44-podman6-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/f44-podman6/repo/fedora-44/rhcontainerbot-f44-podman6-fedora-44.repo
+    curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-f44-podman6-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/f44-podman6/pubkey.gpg
     dnf install --best -y \
     aardvark-dns crun netavark podman containers-common containers-common-extra crun-wasm
 else
@@ -88,9 +88,9 @@ else
     FILE="/var/tmp/rpms/*.rpm"
     if [[ -n $(echo $FILE) ]]; then dnf update -y --best --allowerasing $FILE; fi
 
-    # Temporary get the dependency packages from podman-next so we can get working deps for containers-common and netavark for 6.0.
-    curl --fail -o /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repo
-    curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg
+    # Temporary get the dependency packages from f44-podman6 so we can get working deps for containers-common and netavark for 6.0.
+    curl --fail -o /etc/yum.repos.d/rhcontainerbot-f44-podman6-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/f44-podman6/repo/fedora-44/rhcontainerbot-f44-podman6-fedora-44.repo
+    curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-f44-podman6-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/f44-podman6/pubkey.gpg
     curl --fail -o /etc/yum.repos.d/podman-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/podman-container-tools-podman-${PODMAN_PR_NUM}/repo/fedora-rawhide/packit-podman-container-tools-podman-${PODMAN_PR_NUM}-fedora-rawhide.repo
     curl --fail -o /etc/pki/rpm-gpg/podman-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/podman-container-tools-podman-${PODMAN_PR_NUM}/pubkey.gpg
     dnf install --from-repo=copr:copr.fedorainfracloud.org:packit:podman-container-tools-podman-${PODMAN_PR_NUM} --best -y podman

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -4,6 +4,6 @@
 # at any given time.
 # 2. Both PODMAN_VERSION and PODMAN_PR_NUM will have to be updated manually on release
 # PRs.
-# 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/podman-next` copr.
+# 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/f44-podman6` copr.
 export PODMAN_VERSION="6.0.0-rc1"
 export PODMAN_PR_NUM="28918"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
