### PR TITLE
gh actions: remove workarounds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build images
         run: |
           ./build.sh
-          mv $OUTDIR/podman-machine $OUTDIR/podman-machine.${{ matrix.os.arch }}.tar
 
       # just for debugging, i.e. when mounting failed.
       - name: dmesg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,23 +39,6 @@ jobs:
           submodules: recursive # this repo uses a submodule
       - name: Build images
         run: |
-          # add custom xfs call to not create a fs that cannot be mounted on the older runner kernel
-          # For some reason /usr/local/bin is not being recognized by osbuild so replace the actual binary
-          mv /usr/bin/mkfs.xfs /usr/bin/mkfs.xfs.real
-          cat >/usr/bin/mkfs.xfs <<EOF
-          #!/bin/bash
-          /usr/bin/mkfs.xfs.real -c options=/usr/share/xfsprogs/mkfs/lts_6.6.conf "\$@"
-          EOF
-          chmod +x /usr/bin/mkfs.xfs
-
-          # add getenforce to claim we support selinux even when we do not
-          # https://github.com/coreos/custom-coreos-disk-images/pull/30
-          cat >/usr/local/bin/getenforce <<EOF
-          #!/bin/bash
-          echo "Permissive"
-          EOF
-          chmod +x /usr/local/bin/getenforce
-
           ./build.sh
           mv $OUTDIR/podman-machine $OUTDIR/podman-machine.${{ matrix.os.arch }}.tar
 

--- a/build.sh
+++ b/build.sh
@@ -89,8 +89,6 @@ rpm-ostree compose build-chunked-oci \
         --bootc --from "${FULL_IMAGE_NAME_ARCH}" \
         --output "oci-archive:${OUTDIR}/${DISK_IMAGE_NAME}"
 
-echo "getenforce $(getenforce)"
-
 echo "Transforming OCI image into disk image"
 # Get supported CoreOS platforms for this architecture and convert space-separated to comma-separated
 # (WSL is built separately and not included here)

--- a/build.sh
+++ b/build.sh
@@ -115,6 +115,8 @@ for hypervisor in ${ARCH_TO_COREOS_PLATFORMS[$CPU_ARCH]}; do
   $ZSTD_CMD "$newfilename"
 done
 
+mv "${DISK_IMAGE_NAME}" "${DISK_IMAGE_NAME}.${CPU_ARCH}.tar"
+
 popd
 
 # Wait for the WSL build to finish


### PR DESCRIPTION
The runners now should run on kernel 6.17 which seems to be able to
mount the latest xfs file system fine.

And the custom-coreos-disk-images submodule was updated to allow running
on non selinux systems.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
