### PR TITLE
add nightly rebuilds on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,13 @@ on:
       # Note for other branches (i.e. release branches we do not want pushes by default), only tags should rebuild images there.
     tags:
       - 'v*'
+  schedule:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+    # Note github recommends not running at the top of the hour to the high load which could even drop events, so use a different time.
+    # We just need daily rebuilds, at some time in the night, except on the weekend as there is likely nobody
+    # around to fix the image if it builded something that breaks podman CI all of the sudden.
+    # cron runs also only happen on the default branch (main) which is what we want here.
+    - cron: "25 1 * * 1-5"
 
 permissions: {}
 


### PR DESCRIPTION
With cirrus we had nightly builds so we like to have the some with github actions. Add a cron trigger to do so.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
