### PR TITLE
[v5.8] fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
               fi
           fi
 
-          gh release create $VERSION \
+          gh --repo "$REPO" release create $VERSION \
               -t $VERSION \
               --notes "$VERSION release images" \
               --verify-tag \


### PR DESCRIPTION
Backport of #266

We need to include the repo location to the gh cli so it knows where to create the release because we do not have/need a repo checkout here.


(cherry picked from commit 5be4b845d76e2ffb5e895fc8ec51ebe78d4c953d)

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
