### PR TITLE
teach renovate to update PODMAN_INSTALL_VERSION

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,21 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
     "**/docs/**",
   ],
 
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^.github/workflows/build.yml$/",
+      ],
+      "matchStrings": [
+        "PODMAN_INSTALL_VERSION:\\s+(?<currentValue>.+)\\s*"
+      ],
+      "depNameTemplate": "podman-container-tools/podman",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced",
+    }
+  ],
+
   "addLabels": ["release-note-none"],
 
   /* update the custom-coreos-disk-images submodule */

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 
 env:
-  PODMAN_INSTALL_VERSION: 5.8.2
+  PODMAN_INSTALL_VERSION: v5.8.2
 
 jobs:
   build:
@@ -143,7 +143,7 @@ jobs:
       - name: Install podman
         run: |
           curl --fail -L \
-             https://github.com/containers/podman/releases/download/v$PODMAN_INSTALL_VERSION/podman-remote-static-linux_${{ matrix.os.goarch }}.tar.gz |
+             https://github.com/containers/podman/releases/download/$PODMAN_INSTALL_VERSION/podman-remote-static-linux_${{ matrix.os.goarch }}.tar.gz |
           tar -xvz
 
           mv bin/podman-remote-static-linux_${{ matrix.os.goarch }} bin/podman-remote
@@ -242,7 +242,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          git clone --depth 1 --branch v${PODMAN_INSTALL_VERSION} https://github.com/podman-container-tools/podman.git
+          git clone --depth 1 --branch ${PODMAN_INSTALL_VERSION} https://github.com/podman-container-tools/podman.git
           make -C podman podman-remote
           ./podman/bin/darwin/podman --version
           mkdir bin

--- a/hack/ci/windows_setup.ps1
+++ b/hack/ci/windows_setup.ps1
@@ -21,7 +21,7 @@ function download($uri, $file) {
 }
 
 # Download and install podman
-$uri = "https://github.com/containers/podman/releases/download/v${ENV:PODMAN_INSTALL_VERSION}/podman-installer-windows-amd64.msi"
+$uri = "https://github.com/containers/podman/releases/download/${ENV:PODMAN_INSTALL_VERSION}/podman-installer-windows-amd64.msi"
 $installer = "podman-installer.msi"
 download "$uri" "$installer"
 


### PR DESCRIPTION
To keep it up to date automatically. Note I did not bump podman to v6 manually because I like to see that renovate picks that up after merge.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
