### PR TITLE
bump podman client to v6.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 
 env:
-  PODMAN_INSTALL_VERSION: v5.8.5
+  PODMAN_INSTALL_VERSION: v6.0.1
 
 jobs:
   build:

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -253,12 +253,12 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 			if index >= 0 {
 				imageVersion = version[:index]
 			}
-			// verify the rpm-ostree image inside uses the proper podman image reference
-			sshSession, err := mb.setCmd([]string{"machine", "ssh", machineName, "sudo rpm-ostree status --json | jq -r '.deployments[0].\"container-image-reference\"'"}).run()
+			// verify the bootc image inside uses the proper podman image reference
+			sshSession, err := mb.setCmd([]string{"machine", "ssh", machineName, "sudo bootc status --json | jq -r '.status.booted.image.image | .transport + \" \" +  .image'"}).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sshSession).To(Exit(0))
 			Expect(sshSession.outputToString()).
-				To(Equal("ostree-unverified-registry:quay.io/podman/machine-os:" + imageVersion))
+				To(Equal("registry quay.io/podman/machine-os:" + imageVersion))
 
 			// TODO: there is no 5.5 in the copr yet as podman main would need to be bumped.
 			// But in order to do that it needs working machine images, catch-22.

--- a/verify/image_verify_test.go
+++ b/verify/image_verify_test.go
@@ -100,6 +100,9 @@ func setup() (string, *imageTestBuilder) {
 			Fail("unable to set home dir on windows")
 		}
 	}
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config")); err != nil {
+		Fail("failed to set XDG_CONFIG_HOME dir")
+	}
 	if err := os.Setenv("XDG_RUNTIME_DIR", homeDir); err != nil {
 		Fail("failed to set xdg_runtime dir")
 	}


### PR DESCRIPTION
Make sure we test our image actually with podman 6 and not the older
client.

---

verify: use bootc to check image version inside VM

rpm-ostree no longer works when the machine is created with a podman 6
client as it was hard coding /etc/containers/policy.json which no longer
exists when we overmount /etc/containers and in general the packaged
file has been moved under /usr.

bootc seems to work fine though so you use that to check the version, we
are using bootc commands after all to update the os so this seems better
regardless.



```release-note
None
```
