### PR TITLE
switch to f44 copr to get the right podman deps

### DIFF
--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -87,17 +87,14 @@ else
     shopt -s nullglob
     FILE="/var/tmp/rpms/*.rpm"
     if [[ -n $(echo $FILE) ]]; then dnf update -y --best --allowerasing $FILE; fi
+
+    # Temporary get the dependency packages from f44-podman6 so we can get working deps for containers-common and netavark for 6.0.
+    curl --fail -o /etc/yum.repos.d/rhcontainerbot-f44-podman6-fedora.repo https://copr.fedorainfracloud.org/coprs/rhcontainerbot/f44-podman6/repo/fedora-44/rhcontainerbot-f44-podman6-fedora-44.repo
+    curl --fail -o /etc/pki/rpm-gpg/rhcontainerbot-f44-podman6-fedora.gpg https://download.copr.fedorainfracloud.org/results/rhcontainerbot/f44-podman6/pubkey.gpg
     curl --fail -o /etc/yum.repos.d/podman-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/podman-container-tools-podman-${PODMAN_PR_NUM}/repo/fedora-rawhide/packit-podman-container-tools-podman-${PODMAN_PR_NUM}-fedora-rawhide.repo
     curl --fail -o /etc/pki/rpm-gpg/podman-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/podman-container-tools-podman-${PODMAN_PR_NUM}/pubkey.gpg
-    dnf install --best -y podman
+    dnf install --from-repo=copr:copr.fedorainfracloud.org:packit:podman-container-tools-podman-${PODMAN_PR_NUM} --best -y podman
 fi
-
-curl --fail -o /etc/yum.repos.d/netavark-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/containers-netavark-${NETAVARK_PR_NUM}/repo/fedora-rawhide/packit-containers-netavark-${NETAVARK_PR_NUM}-fedora-rawhide.repo
-curl --fail -o /etc/pki/rpm-gpg/netavark-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/containers-netavark-${NETAVARK_PR_NUM}/pubkey.gpg
-curl --fail -o /etc/yum.repos.d/aardvark-dns-release-copr.repo https://copr.fedorainfracloud.org/coprs/packit/containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}/repo/fedora-rawhide/packit-containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}-fedora-rawhide.repo
-curl --fail -o /etc/pki/rpm-gpg/aardvark-dns-release-copr.gpg https://download.copr.fedorainfracloud.org/results/packit/containers-aardvark-dns-${AARDVARK_DNS_PR_NUM}/pubkey.gpg
-
-dnf install --best -y netavark aardvark-dns
 
 # Install subscription-manager and enable service to refresh certificates
 # Install qemu-user-static for bootc/user emulation

--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -7,8 +7,3 @@
 # 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/podman-next` copr.
 export PODMAN_VERSION="6.1.0-dev"
 export PODMAN_PR_NUM=""
-
-# Temporary work around due the fact that podman 6 needs the new nv/av 2.0 which is also not in
-# the fedora stable repos until f45
-export NETAVARK_PR_NUM="1464"
-export AARDVARK_DNS_PR_NUM="706"


### PR DESCRIPTION
Since we do not ship podman 6 in f44 it has not the right deps for containers-common, netavark v2, etc...

Use a custom copr repo for them as well that was provided by Lokesh.

It is a partial forward port of changes we already did on 6.0: https://github.com/podman-container-tools/podman-machine-os/pull/269

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
