### PR TITLE
bump main image to 6.2

### DIFF
--- a/podman-rpm-info-vars.sh
+++ b/podman-rpm-info-vars.sh
@@ -5,5 +5,5 @@
 # 2. Both PODMAN_VERSION and PODMAN_PR_NUM will have to be updated manually on release
 # PRs.
 # 3. If PODMAN_PR_NUM is empty, rpms will be fetched from the `rhcontainerbot/podman-next` copr.
-export PODMAN_VERSION="6.1.0-dev"
+export PODMAN_VERSION="6.2.0-dev"
 export PODMAN_PR_NUM=""


### PR DESCRIPTION
In preparation for the 6.1 release we need to ensure main builds 6.2 to avoid it overriding the 6.1 tag.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
